### PR TITLE
dégradés sur la timeline

### DIFF
--- a/ktbs4la2-components/ktbs4la2-timeline/ktbs4la2-timeline.css
+++ b/ktbs4la2-components/ktbs4la2-timeline/ktbs4la2-timeline.css
@@ -109,6 +109,8 @@
 
 .time-division:nth-child(odd) { 
 	color: white;
+	background-image: linear-gradient(transparent, #FFF8 4em,  #FFFC);
+	background-size: cover;
 }
 
 .time-division:nth-child(even) {


### PR DESCRIPTION
permet de garder le bénéfice des 'time-division' colorées,
en génant moins la lecture des obsels eux même